### PR TITLE
`NoneOf` and `AnyOf` can validate multiple valued fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
 - Removed `required` flag support from :class:`~fields.HiddenWidget`,
   :class:`~fields.RangeWidget` and :class:`~fields.SelectWidget` to
   conform to W3C :pr:`810`
+- :class:`~wtforms.validators.NoneOf` and :class:`~wtforms.validators.AnyOf`
+  can validate multiple valued fields like :class:`~fields.SelectMultipleField`
+  :pr:`538` :pr:`807`
 
 Version 3.1.2
 -------------

--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -586,7 +586,8 @@ class AnyOf:
         self.values_formatter = values_formatter
 
     def __call__(self, form, field):
-        if field.data in self.values:
+        data = field.data if isinstance(field.data, list) else [field.data]
+        if any(d in self.values for d in data):
             return
 
         message = self.message
@@ -621,7 +622,8 @@ class NoneOf:
         self.values_formatter = values_formatter
 
     def __call__(self, form, field):
-        if field.data not in self.values:
+        data = field.data if isinstance(field.data, list) else [field.data]
+        if not any(d in self.values for d in data):
             return
 
         message = self.message

--- a/tests/validators/test_anyof.py
+++ b/tests/validators/test_anyof.py
@@ -39,3 +39,18 @@ def test_any_of_values_formatter(dummy_form, dummy_field):
         validator(dummy_form, dummy_field)
 
     assert str(e.value) == "test 9::8::7"
+
+
+def test_none_multiple_values(dummy_form, dummy_field):
+    """
+    the validator should work with multiple values like produced
+    by SelectMultiple fields
+    """
+    dummy_field.data = ["a", "e"]
+    validator = AnyOf(["a", "b", "c"])
+    validator(dummy_form, dummy_field)
+
+    dummy_field.data = ["d", "e"]
+    validator = AnyOf(["a", "b", "c"])
+    with pytest.raises(ValueError):
+        validator(dummy_form, dummy_field)

--- a/tests/validators/test_noneof.py
+++ b/tests/validators/test_noneof.py
@@ -20,3 +20,18 @@ def test_none_of_raises(dummy_form, dummy_field):
     validator = NoneOf(["a", "b", "c"])
     with pytest.raises(ValueError):
         validator(dummy_form, dummy_field)
+
+
+def test_none_of_multiple_values(dummy_form, dummy_field):
+    """
+    the validator should work with multiple values like produced
+    by SelectMultiple fields
+    """
+    dummy_field.data = ["d", "e"]
+    validator = NoneOf(["a", "b", "c"])
+    validator(dummy_form, dummy_field)
+
+    dummy_field.data = ["a", "e"]
+    validator = NoneOf(["a", "b", "c"])
+    with pytest.raises(ValueError):
+        validator(dummy_form, dummy_field)


### PR DESCRIPTION
Fixes NoneOf/AnyOf validators not managing SelectMultipleField data.

```python
>>> import wtforms
... from werkzeug.datastructures import ImmutableMultiDict
... class F(wtforms.Form):
...     foo = wtforms.SelectMultipleField(
...         choices=["bar", "baz"],
...         validators=[wtforms.validators.none_of(["baz"])],
...     )
>>> F(ImmutableMultiDict({"foo": "bar"})).validate()
True
>>> F(ImmutableMultiDict({"foo": "baz"})).validate()
True
```

Replaces #538 
Related to #799