### PR TITLE
remove `required` flag usage on some widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Unreleased
   dutch, kazakh, swedish, turkish, slovak, ukranian, spanish, french.
 - Move the repository to the pallets-eco organization.
 - Stop supporting Python 3.9 and start supporting Python 3.13 :pr:`855`
+- Removed `required` flag support from :class:`~fields.HiddenWidget`,
+  :class:`~fields.RangeWidget` and :class:`~fields.SelectWidget` to
+  conform to W3C :pr:`810`
 
 Version 3.1.2
 -------------
@@ -31,7 +34,6 @@ Released 2023-11-01
 - Python 3.12 support :pr:`818`
 - Restored support for 3-items tuple return value from `iter_choices`
   :pr:`816`
-
 
 Version 3.1.0
 -------------

--- a/src/wtforms/widgets/core.py
+++ b/src/wtforms/widgets/core.py
@@ -163,7 +163,6 @@ class Input:
     """
 
     html_params = staticmethod(html_params)
-    validation_attrs = ["required", "disabled"]
 
     def __init__(self, input_type=None):
         if input_type is not None:
@@ -232,6 +231,7 @@ class HiddenInput(Input):
     """
 
     input_type = "hidden"
+    validation_attrs = ["disabled"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -246,6 +246,7 @@ class CheckboxInput(Input):
     """
 
     input_type = "checkbox"
+    validation_attrs = ["required", "disabled"]
 
     def __call__(self, field, **kwargs):
         if getattr(field, "checked", field.data):
@@ -262,6 +263,7 @@ class RadioInput(Input):
     """
 
     input_type = "radio"
+    validation_attrs = ["required", "disabled"]
 
     def __call__(self, field, **kwargs):
         if field.checked:
@@ -301,6 +303,7 @@ class SubmitInput(Input):
     """
 
     input_type = "submit"
+    validation_attrs = ["required", "disabled"]
 
     def __call__(self, field, **kwargs):
         kwargs.setdefault("value", field.label.text)
@@ -568,7 +571,7 @@ class RangeInput(Input):
     """
 
     input_type = "range"
-    validation_attrs = ["required", "disabled", "max", "min", "step"]
+    validation_attrs = ["disabled", "max", "min", "step"]
 
     def __init__(self, step=None):
         self.step = step
@@ -585,3 +588,4 @@ class ColorInput(Input):
     """
 
     input_type = "color"
+    validation_attrs = ["disabled"]


### PR DESCRIPTION
MDN tells that 'required' is not available on Hidden, Range and Color fields.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

Fixes #682