### PR TITLE
use empty string instead of None as form errors key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,14 @@ Unreleased
   can validate multiple valued fields like :class:`~fields.SelectMultipleField`
   :pr:`538` :pr:`807`
 
+- Breaking change: The key for form errors moved from :data:`None` to
+  empty string `""`. :issue:`829` :pr:`858`
+
+.. note::
+   If you need to keep the old behavior you can set the ``_form_error_key``
+   parameter of you form to :data:`None`.
+
+
 Version 3.1.2
 -------------
 

--- a/src/wtforms/form.py
+++ b/src/wtforms/form.py
@@ -30,6 +30,7 @@ class BaseForm:
             prefix += "-"
 
         self.meta = meta
+        self._form_error_key = ""
         self._prefix = prefix
         self._fields = OrderedDict()
 
@@ -155,7 +156,7 @@ class BaseForm:
     def errors(self):
         errors = {name: f.errors for name, f in self._fields.items() if f.errors}
         if self.form_errors:
-            errors[None] = self.form_errors
+            errors[self._form_error_key] = self.form_errors
         return errors
 
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -204,7 +204,7 @@ def test_form_level_errors():
     f = F(a=0, b=1)
     assert not f.validate()
     assert ["a + b should be even"] == f.form_errors
-    assert ["a + b should be even"] == f.errors[None]
+    assert ["a + b should be even"] == f.errors[""]
 
 
 def test_field_adding_disabled():


### PR DESCRIPTION
Also, introduce a private `_form_error_key` variable to let users choose their own key.

fixes #829