### PR TITLE
Fix Length Validator passing `None` when min=0

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -134,7 +134,11 @@ class Length:
             self.field_flags["maxlength"] = self.max
 
     def __call__(self, form, field):
-        length = field.data and len(field.data) or 0
+        if field.data is None:
+            length = -1
+        else:
+            length = len(field.data)
+
         if length >= self.min and (self.max == -1 or length <= self.max):
             return
 

--- a/tests/validators/test_length.py
+++ b/tests/validators/test_length.py
@@ -58,6 +58,7 @@ def test_length_messages(dummy_form, dummy_field, validator, message):
 
     assert message in str(e.value)
 
+
 @pytest.mark.parametrize("min_v, max_v", [(-1, 5)])
 def test_null_str_pass(min_v, max_v, dummy_form, dummy_field):
     """
@@ -67,6 +68,7 @@ def test_null_str_pass(min_v, max_v, dummy_form, dummy_field):
     dummy_field.data = None
     validator = length(min_v, max_v)
     validator(dummy_form, dummy_field)
+
 
 @pytest.mark.parametrize("min_v, max_v", [(0, 5), (0, -1)])
 def test_null_str_fail(min_v, max_v, dummy_form, dummy_field):
@@ -78,6 +80,7 @@ def test_null_str_fail(min_v, max_v, dummy_form, dummy_field):
     validator = length(min_v, max_v)
     with pytest.raises(ValidationError):
         validator(dummy_form, dummy_field)
+
 
 @pytest.mark.parametrize("min_v, max_v", [(0, 5), (0, -1)])
 def test_empty_str_pass(min_v, max_v, dummy_form, dummy_field):

--- a/tests/validators/test_length.py
+++ b/tests/validators/test_length.py
@@ -57,3 +57,33 @@ def test_length_messages(dummy_form, dummy_field, validator, message):
         validator(dummy_form, dummy_field)
 
     assert message in str(e.value)
+
+@pytest.mark.parametrize("min_v, max_v", [(-1, 5)])
+def test_null_str_pass(min_v, max_v, dummy_form, dummy_field):
+    """
+    The null string (field not in submitted formdata, thus field.data is None)
+    should pass when min=-1, ie no minimum required.
+    """
+    dummy_field.data = None
+    validator = length(min_v, max_v)
+    validator(dummy_form, dummy_field)
+
+@pytest.mark.parametrize("min_v, max_v", [(0, 5), (0, -1)])
+def test_null_str_fail(min_v, max_v, dummy_form, dummy_field):
+    """
+    The null string (field not in submitted formdata, thus field.data is None)
+    should fail when min=0
+    """
+    dummy_field.data = None
+    validator = length(min_v, max_v)
+    with pytest.raises(ValidationError):
+        validator(dummy_form, dummy_field)
+
+@pytest.mark.parametrize("min_v, max_v", [(0, 5), (0, -1)])
+def test_empty_str_pass(min_v, max_v, dummy_form, dummy_field):
+    """
+    The empty string ('') should pass when min=0
+    """
+    dummy_field.data = ""
+    validator = length(min_v, max_v)
+    validator(dummy_form, dummy_field)


### PR DESCRIPTION
Closes #872 

I don't think any fields other than `StringField` use the Length validator, so there's no need for an extra `elif not field.data: length = 0` line to apply to falsey values: Truthy data likewise would need to implement the `len` operator in the pre-existing implementation which only string data does. So everything is good.

I've included three stress-test / edge-case scenarios that make the distinction between `None` and `''` clear. The pre-existing implementation fails these tests, and with this PR they pass.
