### PR TITLE
Fix Email validator pip package recommendation

### DIFF
--- a/src/wtforms/validators.py
+++ b/src/wtforms/validators.py
@@ -365,7 +365,7 @@ class Regexp:
 class Email:
     """
     Validates an email address. Requires email_validator package to be
-    installed. For ex: pip install wtforms[email].
+    installed: pip install email_validator.
 
     :param message:
         Error message to raise in case of a validation error.


### PR DESCRIPTION
The current documentation indicates that "pip install wtforms[email]" should be installed. Running that command returns a "no matches found: wtforms[email]"

Describe the issue you are attempting to fix.

Link to any relevant issues or pull requests.

Describe what this patch does to fix the issue.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code
-->
